### PR TITLE
Use a timing-safe comparison for HMAC signature verification

### DIFF
--- a/decode_jwt.sql
+++ b/decode_jwt.sql
@@ -338,6 +338,42 @@ $$ language plpgsql
    set search_path = jwt, public, pg_temp;
 
 /**
+ * Compares two bytea values without leaking, through timing, where they first
+ * differ.
+ *
+ * PostgreSQL's `=` operator on bytea returns as soon as it finds a differing
+ * byte, so the time it takes reveals the length of the matching prefix. For an
+ * HMAC tag (a secret derived from the key) that turns the comparison into an
+ * oracle an attacker could use to forge a signature one byte at a time.
+ *
+ * Rather than rely on a hand-written byte loop being constant-time in an
+ * interpreted language, this uses the double-HMAC technique: both operands are
+ * hashed with a fresh random key, so the subsequent equality test runs over
+ * values the attacker cannot predict and its timing reveals nothing about the
+ * inputs. The result is still exact because equal inputs hash equally under the
+ * same key.
+ *
+ * @param {bytea} a - The first value to compare.
+ * @param {bytea} b - The second value to compare.
+ * @returns {bool} - True when the two values are equal, false otherwise.
+ */
+create or replace function jwt.secure_compare(a bytea, b bytea)
+    returns boolean as
+$$
+declare
+    blinding_key bytea := gen_random_bytes(32);
+begin
+    if a is null or b is null then
+        return false;
+    end if;
+
+    return hmac(a, blinding_key, 'sha256') = hmac(b, blinding_key, 'sha256');
+end;
+$$ language plpgsql
+   volatile
+   set search_path = jwt, public, pg_temp;
+
+/**
  * Validates the registered claims of an already signature-verified JWT.
  *
  * Time-based claims are only enforced when present: a token without an `exp`
@@ -631,7 +667,9 @@ begin
                 urlsafe_b64decode((keyrecord ->> 'k')::text), -- key
                 hash_algorithm -- type
             );
-            if expected_signature = signature then
+            -- Compare the computed HMAC against the token's signature without
+            -- leaking, through timing, how many leading bytes matched.
+            if secure_compare(expected_signature, signature) then
                 -- The signature is authentic; the token is only accepted if its
                 -- registered claims also pass validation.
                 if validate_claims(claims, audience, issuer, leeway,


### PR DESCRIPTION
## Problem

The HMAC path verified the signature with:

```sql
if expected_signature = signature then
```

The bytea `=` operator short-circuits on the first differing byte, so the comparison's running time reveals the length of the matching prefix. Because `expected_signature` is a secret HMAC tag (derived from the signing key), this is the classic timing side-channel that lets an attacker recover a valid tag one byte at a time and forge a token. (The RSA path is **not** affected — see below.)

## Fix

Add `jwt.secure_compare(a, b)` and use it for the HMAC check.

Rather than relying on a hand-written byte loop actually being constant-time in an interpreted language like PL/pgSQL (the interpreter, integer ops, etc. give no such guarantee), it uses the well-established **double-HMAC** technique:

```sql
blinding_key bytea := gen_random_bytes(32);
...
return hmac(a, blinding_key, 'sha256') = hmac(b, blinding_key, 'sha256');
```

Both operands are hashed with a fresh random key before comparison, so the final equality test runs over values the attacker cannot predict — its timing (and short-circuit point) reveals nothing about `a` or `b`. The result stays exact because equal inputs hash equally under the same key. This relies only on `pgcrypto` (already a dependency).

## Why RSA is left alone

`rsa_signature_matches` compares the expected PKCS#1 padding against `signature^e mod n`. Both sides are computed purely from **public** values (the message, the hash, and the public key), so an attacker already knows them and the comparison timing leaks no secret. Wrapping it in the blinding compare would add two HMACs per key for no security benefit, so it's intentionally unchanged.

## Notes

- `secure_compare` is `VOLATILE` (it calls `gen_random_bytes`). `decode_jwt` remains `STABLE`: the *result* of the comparison is deterministic — the random key only perturbs timing, not the boolean — so `decode_jwt`'s output is still a pure function of its arguments.

## Testing

Against a live PostgreSQL 16 instance using the project's `regresql` harness:

- **Full suite green: 29/29**, no regressions.
- Unit-checked `secure_compare`: equal → true; differ in first byte / last byte / length / null operand → false; empty-vs-empty → true.
- End-to-end through `decode_jwt`: HS256/384/512 valid tokens accepted, tampered signatures rejected (6/6).

https://claude.ai/code/session_01FCfMBLqUKNM7oo6yjckGGK

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCfMBLqUKNM7oo6yjckGGK)_