### PR TITLE
Harden claim validation against malformed aud/exp/nbf values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,9 @@ Temporary Items
 
 # RegreSQL
 */regresql/out
+
+# Python
+__pycache__/
+*.py[cod]
+.venv/
+venv/

--- a/decode_jwt.sql
+++ b/decode_jwt.sql
@@ -406,33 +406,50 @@ begin
     end if;
 
     -- exp: reject once the current time passes the expiration (plus leeway).
+    -- A non-numeric claim, or a numeric value so large that it overflows the
+    -- timestamp range, is treated as an invalid token rather than allowed to
+    -- raise: the conversion is guarded so the function fails closed.
     if validate_exp and claims ? 'exp' then
         if jsonb_typeof(claims -> 'exp') <> 'number' then
             return false;
         end if;
-        if validation_time > to_timestamp((claims ->> 'exp')::numeric) + leeway then
-            return false;
-        end if;
+        begin
+            if validation_time > to_timestamp((claims ->> 'exp')::numeric) + leeway then
+                return false;
+            end if;
+        exception
+            when others then
+                return false;
+        end;
     end if;
 
     -- nbf: reject while the current time is before the not-before (minus leeway).
+    -- Guarded the same way as `exp` above so an out-of-range value fails closed.
     if validate_nbf and claims ? 'nbf' then
         if jsonb_typeof(claims -> 'nbf') <> 'number' then
             return false;
         end if;
-        if validation_time < to_timestamp((claims ->> 'nbf')::numeric) - leeway then
-            return false;
-        end if;
+        begin
+            if validation_time < to_timestamp((claims ->> 'nbf')::numeric) - leeway then
+                return false;
+            end if;
+        exception
+            when others then
+                return false;
+        end;
     end if;
 
     -- aud: when an expected audience is supplied, the token's `aud` claim
-    -- (a string or an array of strings) must contain it.
+    -- (a string or an array of strings, per RFC 7519) must contain it. Any
+    -- other shape -- absent, JSON null, a number, an object, or an array that
+    -- does not hold the expected string -- is rejected. The `?` operator only
+    -- matches string array elements, so numeric members never satisfy it.
     if audience is not null then
         if jsonb_typeof(claims -> 'aud') = 'array' then
             if not (claims -> 'aud' ? audience) then
                 return false;
             end if;
-        elsif claims ? 'aud' then
+        elsif jsonb_typeof(claims -> 'aud') = 'string' then
             if claims ->> 'aud' <> audience then
                 return false;
             end if;

--- a/tests/generate_plans.py
+++ b/tests/generate_plans.py
@@ -158,19 +158,30 @@ def main() -> None:
         )
         return {"token": token, "jwk": json.dumps(claims_key.as_dict())}
 
+    # 1e308 is finite JSON but overflows PostgreSQL's timestamp range; the
+    # exp/nbf checks must reject it rather than letting to_timestamp raise.
+    overflow_epoch = 1e308
+
     # Exercised through decode_jwt with default validation (exp/nbf enforced).
     claimsTests = {
         "exp_valid": claims_vector({"aud": "postgresql", "exp": far_future}),
         "exp_expired": claims_vector({"aud": "postgresql", "exp": far_past}),
         "nbf_valid": claims_vector({"aud": "postgresql", "nbf": far_past}),
         "nbf_future": claims_vector({"aud": "postgresql", "nbf": far_future}),
+        "exp_overflow": claims_vector({"aud": "postgresql", "exp": overflow_epoch}),
+        "nbf_overflow": claims_vector({"aud": "postgresql", "nbf": overflow_epoch}),
     }
-    # Exercised through decode_jwt with audience := 'postgresql'.
+    # Exercised through decode_jwt with audience := 'postgresql'. The trailing
+    # cases pin down the audience check against malformed `aud` claims: a JSON
+    # null and a number must both be rejected (a number that stringifies to the
+    # expected audience must not be accepted through `->>`).
     claimsAudTests = {
         "aud_match": claims_vector({"aud": "postgresql"}),
         "aud_match_array": claims_vector({"aud": ["other", "postgresql"]}),
         "aud_mismatch": claims_vector({"aud": "other"}),
         "aud_absent": claims_vector({"sub": "user"}),
+        "aud_null": claims_vector({"aud": None}),
+        "aud_number": claims_vector({"aud": 123}),
     }
     # Exercised through decode_jwt with issuer := 'https://example.com'.
     claimsIssTests = {

--- a/tests/regresql/expected/decode_jwt_claims.exp_overflow.out
+++ b/tests/regresql/expected/decode_jwt_claims.exp_overflow.out
@@ -1,0 +1,3 @@
+decode_jwt_claims
+-----------------
+<nil>

--- a/tests/regresql/expected/decode_jwt_claims.nbf_overflow.out
+++ b/tests/regresql/expected/decode_jwt_claims.nbf_overflow.out
@@ -1,0 +1,3 @@
+decode_jwt_claims
+-----------------
+<nil>

--- a/tests/regresql/expected/decode_jwt_claims_aud.aud_null.out
+++ b/tests/regresql/expected/decode_jwt_claims_aud.aud_null.out
@@ -1,0 +1,3 @@
+decode_jwt_claims_aud
+---------------------
+<nil>

--- a/tests/regresql/expected/decode_jwt_claims_aud.aud_number.out
+++ b/tests/regresql/expected/decode_jwt_claims_aud.aud_number.out
@@ -1,0 +1,3 @@
+decode_jwt_claims_aud
+---------------------
+<nil>

--- a/tests/regresql/plans/decode_jwt_claims.yaml
+++ b/tests/regresql/plans/decode_jwt_claims.yaml
@@ -1,12 +1,18 @@
 exp_expired:
   jwk: '{"k": "xmxpKfr_njglSLF0zYB3YjgIYQ5COhXMfr-OgG6s-H8", "alg": "HS256", "use": "sig", "kid": "985c02cb-2cbb-4bc7-96bc-56a427dbf49d", "kty": "oct"}'
   token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6Ijk4NWMwMmNiLTJjYmItNGJjNy05NmJjLTU2YTQyN2RiZjQ5ZCJ9.eyJhdWQiOiJwb3N0Z3Jlc3FsIiwiZXhwIjoxfQ.dOJGQBtJKC4dMOENl3-MuQAe4HDCWAzbCNIHSo1bC5U
+exp_overflow:
+  jwk: '{"k": "xmxpKfr_njglSLF0zYB3YjgIYQ5COhXMfr-OgG6s-H8", "alg": "HS256", "use": "sig", "kid": "985c02cb-2cbb-4bc7-96bc-56a427dbf49d", "kty": "oct"}'
+  token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6Ijk4NWMwMmNiLTJjYmItNGJjNy05NmJjLTU2YTQyN2RiZjQ5ZCJ9.eyJhdWQiOiJwb3N0Z3Jlc3FsIiwiZXhwIjoxZSszMDh9.QDujKXF-FUeHaENV-ozS0778k9cJvNQC3dhEvH-80Mw
 exp_valid:
   jwk: '{"k": "xmxpKfr_njglSLF0zYB3YjgIYQ5COhXMfr-OgG6s-H8", "alg": "HS256", "use": "sig", "kid": "985c02cb-2cbb-4bc7-96bc-56a427dbf49d", "kty": "oct"}'
   token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6Ijk4NWMwMmNiLTJjYmItNGJjNy05NmJjLTU2YTQyN2RiZjQ5ZCJ9.eyJhdWQiOiJwb3N0Z3Jlc3FsIiwiZXhwIjo3MjU4MTE4NDAwfQ.oZBD-9ZNKqb5-C2uJmFnV4oiKiFbSxuqXPFrIP8wyP4
 nbf_future:
   jwk: '{"k": "xmxpKfr_njglSLF0zYB3YjgIYQ5COhXMfr-OgG6s-H8", "alg": "HS256", "use": "sig", "kid": "985c02cb-2cbb-4bc7-96bc-56a427dbf49d", "kty": "oct"}'
   token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6Ijk4NWMwMmNiLTJjYmItNGJjNy05NmJjLTU2YTQyN2RiZjQ5ZCJ9.eyJhdWQiOiJwb3N0Z3Jlc3FsIiwibmJmIjo3MjU4MTE4NDAwfQ.YDJQGEBN4MLevew1j6hJpk5fGMguEGux31dzHTvQag4
+nbf_overflow:
+  jwk: '{"k": "xmxpKfr_njglSLF0zYB3YjgIYQ5COhXMfr-OgG6s-H8", "alg": "HS256", "use": "sig", "kid": "985c02cb-2cbb-4bc7-96bc-56a427dbf49d", "kty": "oct"}'
+  token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6Ijk4NWMwMmNiLTJjYmItNGJjNy05NmJjLTU2YTQyN2RiZjQ5ZCJ9.eyJhdWQiOiJwb3N0Z3Jlc3FsIiwibmJmIjoxZSszMDh9.pH5hGQEA04fDDRsWeEi56BRBwQdXuv4TlzFnbC48E7s
 nbf_valid:
   jwk: '{"k": "xmxpKfr_njglSLF0zYB3YjgIYQ5COhXMfr-OgG6s-H8", "alg": "HS256", "use": "sig", "kid": "985c02cb-2cbb-4bc7-96bc-56a427dbf49d", "kty": "oct"}'
   token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6Ijk4NWMwMmNiLTJjYmItNGJjNy05NmJjLTU2YTQyN2RiZjQ5ZCJ9.eyJhdWQiOiJwb3N0Z3Jlc3FsIiwibmJmIjoxfQ.tQCyjuQjz06rvWL8W9ebnysP_qzcjvJfb4HOK8ywsZU

--- a/tests/regresql/plans/decode_jwt_claims_aud.yaml
+++ b/tests/regresql/plans/decode_jwt_claims_aud.yaml
@@ -10,3 +10,9 @@ aud_match_array:
 aud_mismatch:
   jwk: '{"k": "xmxpKfr_njglSLF0zYB3YjgIYQ5COhXMfr-OgG6s-H8", "alg": "HS256", "use": "sig", "kid": "985c02cb-2cbb-4bc7-96bc-56a427dbf49d", "kty": "oct"}'
   token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6Ijk4NWMwMmNiLTJjYmItNGJjNy05NmJjLTU2YTQyN2RiZjQ5ZCJ9.eyJhdWQiOiJvdGhlciJ9.bCK54LM5PTvAx-7_kzu9ZJ-7xo-OBRx9kCnVappwZNU
+aud_null:
+  jwk: '{"k": "xmxpKfr_njglSLF0zYB3YjgIYQ5COhXMfr-OgG6s-H8", "alg": "HS256", "use": "sig", "kid": "985c02cb-2cbb-4bc7-96bc-56a427dbf49d", "kty": "oct"}'
+  token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6Ijk4NWMwMmNiLTJjYmItNGJjNy05NmJjLTU2YTQyN2RiZjQ5ZCJ9.eyJhdWQiOm51bGx9.Dt11sNTyGcIV25zunJ5EduJKBiURTizYA7euEih0eUA
+aud_number:
+  jwk: '{"k": "xmxpKfr_njglSLF0zYB3YjgIYQ5COhXMfr-OgG6s-H8", "alg": "HS256", "use": "sig", "kid": "985c02cb-2cbb-4bc7-96bc-56a427dbf49d", "kty": "oct"}'
+  token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6Ijk4NWMwMmNiLTJjYmItNGJjNy05NmJjLTU2YTQyN2RiZjQ5ZCJ9.eyJhdWQiOjEyM30._dIrPP4glKGuxXRCjhV8pdoou7MDfSpz5X7jeYUUo-M


### PR DESCRIPTION
## Summary

Follow-up security audit after the previous round of fixes. The cryptographic core (timing-safe HMAC comparison, modulus-derived RSA key size, oversized-exponent guard, PKCS#1 v1.5 padding verification) holds up; the remaining gaps were in the claims-validation layer, where a token with a **valid signature** but a malformed claim could slip past a check. All issues were reproduced and the fixes verified against a live PostgreSQL 16 + pgcrypto instance.

### Changes to `jwt.validate_claims`

- **`aud` type confusion**: when an expected `audience` is supplied, only a JSON string or an array of strings can satisfy the check (per RFC 7519). Previously a JSON-null `aud` made the comparison evaluate to SQL NULL (not true) and bypassed audience validation entirely, and a numeric `aud` was accepted whenever it stringified to the expected value.
- **`exp`/`nbf` fail closed**: a finite but out-of-range numeric (e.g. `1e308`) overflowed `to_timestamp` and raised an error, breaking `decode_jwt`'s "return null on an invalid token" contract. The conversions are now guarded so such values reject the token instead of raising.

### Tests

- New regression vectors: `aud_null`, `aud_number`, `exp_overflow`, `nbf_overflow`, signed with the existing shared HMAC test key so the other committed vectors are unchanged.
- `generate_plans.py` updated so the new cases survive plan regeneration.
- All existing vectors verified to still pass.

Also adds Python artifacts (`__pycache__/` etc.) to `.gitignore`.

https://claude.ai/code/session_01TUXKrSvKLEwWeqqdpmjuqs

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUXKrSvKLEwWeqqdpmjuqs)_