### PR TITLE
Add JWT attack regression suite and reject non-object payloads

### DIFF
--- a/decode_jwt.sql
+++ b/decode_jwt.sql
@@ -405,6 +405,15 @@ begin
         return false;
     end if;
 
+    -- RFC 7519 defines the JWT Claims Set as a JSON object. A validly-signed
+    -- token whose payload decodes to a scalar or array carries no registered
+    -- claims to check, so the exp/nbf/aud/iss guards below would vacuously pass
+    -- and the bogus value would be returned to the caller. Reject any non-object
+    -- payload outright so the function fails closed.
+    if jsonb_typeof(claims) <> 'object' then
+        return false;
+    end if;
+
     -- exp: reject once the current time passes the expiration (plus leeway).
     -- A non-numeric claim, or a numeric value so large that it overflows the
     -- timestamp range, is treated as an invalid token rather than allowed to

--- a/tests/decode_jwt_security.sql
+++ b/tests/decode_jwt_security.sql
@@ -1,0 +1,6 @@
+select jwt.decode_jwt(
+    token := :token,
+    keys := jsonb_build_array(
+       jwt.jwk_to_key(:jwk)
+    )
+) as decode_jwt_security;

--- a/tests/generate_plans.py
+++ b/tests/generate_plans.py
@@ -22,6 +22,8 @@
 # SOFTWARE.
 #
 import base64
+import hashlib
+import hmac
 import json
 from pathlib import Path
 from uuid import uuid4
@@ -190,6 +192,103 @@ def main() -> None:
         "iss_absent": claims_vector({"sub": "user"}),
     }
 
+    # Security-property vectors. Each case is fed to decode_jwt with a single
+    # key and, apart from the positive control, must be rejected (return null).
+    # These pin down the resistance to the well-known JWT attacks: the unsigned
+    # `alg: none` token, RSA->HMAC algorithm confusion (an HS256 token forged
+    # using the published RSA public key as the HMAC secret), verification
+    # against the wrong key, signature stripping/tampering, structurally
+    # malformed tokens, and validly-signed but non-object payloads.
+
+    def b64u(data: bytes) -> str:
+        """URL-safe base64 without padding, matching the JWT segment encoding."""
+        return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+    def hs256_raw(payload: bytes, secret: bytes) -> str:
+        """Sign an arbitrary (possibly non-object) payload as an HS256 JWT.
+
+        joserfc's encoder only accepts an object claims set, so the payload is
+        assembled and HMAC-signed by hand to cover the malformed-payload cases.
+        """
+        signing_input = f'{b64u(json.dumps({"alg": "HS256"}).encode())}.{b64u(payload)}'
+        signature = hmac.new(secret, signing_input.encode(), hashlib.sha256).digest()
+        return f"{signing_input}.{b64u(signature)}"
+
+    # The legitimate key the server trusts, plus a second, unrelated key used to
+    # prove a token does not verify against a key it was not signed with.
+    sec_kid = str(uuid4())
+    sec_key = jwk.OctKey.generate_key(
+        key_size=256,
+        parameters={"alg": "HS256", "use": "sig", "kid": sec_kid},
+    )
+    sec_jwk = json.dumps(sec_key.as_dict())
+    sec_secret = base64.urlsafe_b64decode(sec_key.as_dict()["k"] + "==")
+
+    other_kid = str(uuid4())
+    other_key = jwk.OctKey.generate_key(
+        key_size=256,
+        parameters={"alg": "HS256", "use": "sig", "kid": other_kid},
+    )
+    other_jwk = json.dumps(other_key.as_dict())
+
+    # An RSA key whose public part the server publishes. An attacker who only
+    # knows the public key tries to forge an HS256 token using the PEM-encoded
+    # public key as the HMAC secret; the key's own `alg` (RS256) must keep it
+    # from ever being used to verify an HS256 token.
+    sec_rsa_kid = str(uuid4())
+    sec_rsa_key = jwk.RSAKey.generate_key(
+        key_size=2048,
+        parameters={"alg": "RS256", "use": "sig", "kid": sec_rsa_kid},
+    )
+    sec_rsa_jwk = json.dumps(sec_rsa_key.as_dict(private=False))
+    rsa_pub_pem = sec_rsa_key.as_pem(private=False)
+
+    # A genuine HS256 token signed with the trusted key (positive control).
+    valid_token = jwt.encode(
+        header={"alg": "HS256", "kid": sec_kid},
+        claims={"aud": "postgresql"},
+        key=sec_key,
+        algorithms=["HS256"],
+        registry=registry,
+    )
+    v_header, v_payload, v_signature = valid_token.split(".")
+
+    # alg: none, carrying privileged-looking claims and an empty signature.
+    none_token = (
+        f'{b64u(json.dumps({"alg": "none", "kid": sec_kid}).encode())}.'
+        f'{b64u(json.dumps({"aud": "postgresql", "sub": "admin"}).encode())}.'
+    )
+
+    # HS256 token forged with the RSA public PEM as the HMAC secret.
+    confusion_input = (
+        f'{b64u(json.dumps({"alg": "HS256", "kid": sec_rsa_kid}).encode())}.'
+        f'{b64u(json.dumps({"aud": "postgresql", "sub": "admin"}).encode())}'
+    )
+    confusion_sig = hmac.new(
+        rsa_pub_pem, confusion_input.encode(), hashlib.sha256
+    ).digest()
+    confusion_token = f"{confusion_input}.{b64u(confusion_sig)}"
+
+    # Flip the final character of a valid signature to corrupt it.
+    tampered_sig = v_signature[:-1] + ("A" if v_signature[-1] != "A" else "B")
+
+    securityTests = {
+        "valid_control": {"token": valid_token, "jwk": sec_jwk},
+        "alg_none": {"token": none_token, "jwk": sec_rsa_jwk},
+        "alg_confusion_rsa_hmac": {"token": confusion_token, "jwk": sec_rsa_jwk},
+        "wrong_key": {"token": valid_token, "jwk": other_jwk},
+        "tampered_signature": {
+            "token": f"{v_header}.{v_payload}.{tampered_sig}",
+            "jwk": sec_jwk,
+        },
+        "stripped_signature": {"token": f"{v_header}.{v_payload}.", "jwk": sec_jwk},
+        "two_segments": {"token": f"{v_header}.{v_payload}", "jwk": sec_jwk},
+        "one_segment": {"token": "not-a-jwt", "jwk": sec_jwk},
+        "garbage_segments": {"token": "@@@.###.$$$", "jwk": sec_jwk},
+        "payload_scalar": {"token": hs256_raw(b'"admin"', sec_secret), "jwk": sec_jwk},
+        "payload_array": {"token": hs256_raw(b"[1,2,3]", sec_secret), "jwk": sec_jwk},
+    }
+
     # A key whose RSA exponent exceeds the supported int range must be skipped
     # gracefully rather than raising. Pairing such a key with a valid one in the
     # same set proves the oversized key does not poison verification.
@@ -248,6 +347,10 @@ def main() -> None:
     # Write the oversized-exponent test dictionary to its 'yaml' file
     with PLANS_PATH.joinpath("decode_jwt_rsa_bigexp.yaml").open("wt") as f:
         yaml.safe_dump(data=rsaBigExpTests, stream=f, width=BIGINT)
+
+    # Write the security-property test dictionary to its 'yaml' file
+    with PLANS_PATH.joinpath("decode_jwt_security.yaml").open("wt") as f:
+        yaml.safe_dump(data=securityTests, stream=f, width=BIGINT)
 
 
 if __name__ == "__main__":

--- a/tests/regresql/expected/decode_jwt_security.alg_confusion_rsa_hmac.out
+++ b/tests/regresql/expected/decode_jwt_security.alg_confusion_rsa_hmac.out
@@ -1,0 +1,3 @@
+decode_jwt_security
+-------------------
+<nil>

--- a/tests/regresql/expected/decode_jwt_security.alg_none.out
+++ b/tests/regresql/expected/decode_jwt_security.alg_none.out
@@ -1,0 +1,3 @@
+decode_jwt_security
+-------------------
+<nil>

--- a/tests/regresql/expected/decode_jwt_security.garbage_segments.out
+++ b/tests/regresql/expected/decode_jwt_security.garbage_segments.out
@@ -1,0 +1,3 @@
+decode_jwt_security
+-------------------
+<nil>

--- a/tests/regresql/expected/decode_jwt_security.one_segment.out
+++ b/tests/regresql/expected/decode_jwt_security.one_segment.out
@@ -1,0 +1,3 @@
+decode_jwt_security
+-------------------
+<nil>

--- a/tests/regresql/expected/decode_jwt_security.payload_array.out
+++ b/tests/regresql/expected/decode_jwt_security.payload_array.out
@@ -1,0 +1,3 @@
+decode_jwt_security
+-------------------
+<nil>

--- a/tests/regresql/expected/decode_jwt_security.payload_scalar.out
+++ b/tests/regresql/expected/decode_jwt_security.payload_scalar.out
@@ -1,0 +1,3 @@
+decode_jwt_security
+-------------------
+<nil>

--- a/tests/regresql/expected/decode_jwt_security.stripped_signature.out
+++ b/tests/regresql/expected/decode_jwt_security.stripped_signature.out
@@ -1,0 +1,3 @@
+decode_jwt_security
+-------------------
+<nil>

--- a/tests/regresql/expected/decode_jwt_security.tampered_signature.out
+++ b/tests/regresql/expected/decode_jwt_security.tampered_signature.out
@@ -1,0 +1,3 @@
+decode_jwt_security
+-------------------
+<nil>

--- a/tests/regresql/expected/decode_jwt_security.two_segments.out
+++ b/tests/regresql/expected/decode_jwt_security.two_segments.out
@@ -1,0 +1,3 @@
+decode_jwt_security
+-------------------
+<nil>

--- a/tests/regresql/expected/decode_jwt_security.valid_control.out
+++ b/tests/regresql/expected/decode_jwt_security.valid_control.out
@@ -1,0 +1,3 @@
+ decode_jwt_security 
+---------------------
+{"aud": "postgresql"}

--- a/tests/regresql/expected/decode_jwt_security.wrong_key.out
+++ b/tests/regresql/expected/decode_jwt_security.wrong_key.out
@@ -1,0 +1,3 @@
+decode_jwt_security
+-------------------
+<nil>

--- a/tests/regresql/plans/decode_jwt_security.yaml
+++ b/tests/regresql/plans/decode_jwt_security.yaml
@@ -1,0 +1,33 @@
+alg_confusion_rsa_hmac:
+  jwk: '{"n": "zaNEp44d32NrEqstRn15qWdvsuXnKf6Qc27PftX-iOrH1ZzYMZJAWMBsVrREXE33fcNwyO6EDpPYyaUhmCLVM1lHXA34bf9MPJsvd-fvd6ucp3uuuBjmXLADX9MlOJ38G_AuSYDnsYuX2_Aq9YoNuRCfONB0lLotjyIShkh4iHYNUg_iokPltNEZJR5SYjG8K_5O-9cTr3mATM5tvfn9pzmogStjT44iurO_E4SYbRzu-njVP19coczUuNEUcxS_lB71Y_o8McINePgNM6_qdr5kXQzzuHBfDpLpZbZMhMOuOyVr70V5mvCrIV1QIIq61ZmU2lFGkrMQa2QvHTYUZw", "e": "AQAB", "alg": "RS256", "use": "sig", "kid": "8d16a5fe-dec6-42e2-9cc9-b52275c442a5", "kty": "RSA"}'
+  token: eyJhbGciOiAiSFMyNTYiLCAia2lkIjogIjhkMTZhNWZlLWRlYzYtNDJlMi05Y2M5LWI1MjI3NWM0NDJhNSJ9.eyJhdWQiOiAicG9zdGdyZXNxbCIsICJzdWIiOiAiYWRtaW4ifQ.no2P6f9M6ZxJnLqf7QIByWEogqIUTFVUwsjPxmMAjJ8
+alg_none:
+  jwk: '{"n": "zaNEp44d32NrEqstRn15qWdvsuXnKf6Qc27PftX-iOrH1ZzYMZJAWMBsVrREXE33fcNwyO6EDpPYyaUhmCLVM1lHXA34bf9MPJsvd-fvd6ucp3uuuBjmXLADX9MlOJ38G_AuSYDnsYuX2_Aq9YoNuRCfONB0lLotjyIShkh4iHYNUg_iokPltNEZJR5SYjG8K_5O-9cTr3mATM5tvfn9pzmogStjT44iurO_E4SYbRzu-njVP19coczUuNEUcxS_lB71Y_o8McINePgNM6_qdr5kXQzzuHBfDpLpZbZMhMOuOyVr70V5mvCrIV1QIIq61ZmU2lFGkrMQa2QvHTYUZw", "e": "AQAB", "alg": "RS256", "use": "sig", "kid": "8d16a5fe-dec6-42e2-9cc9-b52275c442a5", "kty": "RSA"}'
+  token: eyJhbGciOiAibm9uZSIsICJraWQiOiAiMzU4ODU2NGYtY2YyNy00ZDFiLTg2YjQtNTE4Y2RjZGRjZWE5In0.eyJhdWQiOiAicG9zdGdyZXNxbCIsICJzdWIiOiAiYWRtaW4ifQ.
+garbage_segments:
+  jwk: '{"k": "l1H7gRpdon3nFaXgxIQfuuQ745bxqbiW3ImbCJlc6Co", "alg": "HS256", "use": "sig", "kid": "3588564f-cf27-4d1b-86b4-518cdcddcea9", "kty": "oct"}'
+  token: '@@@.###.$$$'
+one_segment:
+  jwk: '{"k": "l1H7gRpdon3nFaXgxIQfuuQ745bxqbiW3ImbCJlc6Co", "alg": "HS256", "use": "sig", "kid": "3588564f-cf27-4d1b-86b4-518cdcddcea9", "kty": "oct"}'
+  token: not-a-jwt
+payload_array:
+  jwk: '{"k": "l1H7gRpdon3nFaXgxIQfuuQ745bxqbiW3ImbCJlc6Co", "alg": "HS256", "use": "sig", "kid": "3588564f-cf27-4d1b-86b4-518cdcddcea9", "kty": "oct"}'
+  token: eyJhbGciOiAiSFMyNTYifQ.WzEsMiwzXQ.uCbaHBnmGrUFgrDkP6ZkHA0-ey-kXnSSNasAfUiQA1w
+payload_scalar:
+  jwk: '{"k": "l1H7gRpdon3nFaXgxIQfuuQ745bxqbiW3ImbCJlc6Co", "alg": "HS256", "use": "sig", "kid": "3588564f-cf27-4d1b-86b4-518cdcddcea9", "kty": "oct"}'
+  token: eyJhbGciOiAiSFMyNTYifQ.ImFkbWluIg.Xq1W5e-Pa2SJIHVuHzI5ni2l_uhfssK0SHQzdnlGMFw
+stripped_signature:
+  jwk: '{"k": "l1H7gRpdon3nFaXgxIQfuuQ745bxqbiW3ImbCJlc6Co", "alg": "HS256", "use": "sig", "kid": "3588564f-cf27-4d1b-86b4-518cdcddcea9", "kty": "oct"}'
+  token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6IjM1ODg1NjRmLWNmMjctNGQxYi04NmI0LTUxOGNkY2RkY2VhOSJ9.eyJhdWQiOiJwb3N0Z3Jlc3FsIn0.
+tampered_signature:
+  jwk: '{"k": "l1H7gRpdon3nFaXgxIQfuuQ745bxqbiW3ImbCJlc6Co", "alg": "HS256", "use": "sig", "kid": "3588564f-cf27-4d1b-86b4-518cdcddcea9", "kty": "oct"}'
+  token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6IjM1ODg1NjRmLWNmMjctNGQxYi04NmI0LTUxOGNkY2RkY2VhOSJ9.eyJhdWQiOiJwb3N0Z3Jlc3FsIn0.1QGS6f5deiFIknwpJYGwgbKmWjt22VQXZXoWw_ODypA
+two_segments:
+  jwk: '{"k": "l1H7gRpdon3nFaXgxIQfuuQ745bxqbiW3ImbCJlc6Co", "alg": "HS256", "use": "sig", "kid": "3588564f-cf27-4d1b-86b4-518cdcddcea9", "kty": "oct"}'
+  token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6IjM1ODg1NjRmLWNmMjctNGQxYi04NmI0LTUxOGNkY2RkY2VhOSJ9.eyJhdWQiOiJwb3N0Z3Jlc3FsIn0
+valid_control:
+  jwk: '{"k": "l1H7gRpdon3nFaXgxIQfuuQ745bxqbiW3ImbCJlc6Co", "alg": "HS256", "use": "sig", "kid": "3588564f-cf27-4d1b-86b4-518cdcddcea9", "kty": "oct"}'
+  token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6IjM1ODg1NjRmLWNmMjctNGQxYi04NmI0LTUxOGNkY2RkY2VhOSJ9.eyJhdWQiOiJwb3N0Z3Jlc3FsIn0.1QGS6f5deiFIknwpJYGwgbKmWjt22VQXZXoWw_ODypY
+wrong_key:
+  jwk: '{"k": "Lv8pDtSTLdeOKFMKo-DwpNpQ2TseSaeZS0Qf50oUO0E", "alg": "HS256", "use": "sig", "kid": "8aaa6371-2d99-4893-bfab-94d3bf04a653", "kty": "oct"}'
+  token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6IjM1ODg1NjRmLWNmMjctNGQxYi04NmI0LTUxOGNkY2RkY2VhOSJ9.eyJhdWQiOiJwb3N0Z3Jlc3FsIn0.1QGS6f5deiFIknwpJYGwgbKmWjt22VQXZXoWw_ODypY


### PR DESCRIPTION
## Summary

Locks in the verifier's resistance to the well-known JWT attacks with a new `decode_jwt_security` regresql suite, and closes the one gap it exposed.

I stood up a live PostgreSQL 16 instance, installed the functions, and probed `decode_jwt` against the classic JWT attack classes. The library already withstands almost all of them — but none of that was covered by tests, so a future change could silently regress it.

## New security suite (`tests/decode_jwt_security.sql`)

Eleven vectors, each confirming `decode_jwt` returns `null` for:

- `alg: none` unsigned tokens
- **RSA→HMAC algorithm confusion** — an HS256 token forged using the published RSA public key (PEM) as the HMAC secret, verified against the RSA key set
- verification against the wrong key
- tampered and stripped signatures
- structurally malformed tokens (too few segments, non-base64 garbage)
- validly-signed but non-object payloads

A positive control proves the negative results are meaningful.

## Hardening (`decode_jwt.sql`)

The non-object-payload cases revealed a real gap: a validly-signed token whose payload decodes to a JSON **scalar or array** (e.g. `"admin"` or `[1,2,3]`) was returned to the caller as-is. The `exp`/`nbf`/`aud`/`iss` guards in `validate_claims` vacuously passed because there were no registered claims to check.

RFC 7519 defines the JWT Claims Set as a JSON object, so `validate_claims` now rejects any non-object payload and the function fails closed.

## Testing

Full suite runs **45 tests, all passing** (was 34). Unrelated plan files that only churned due to the generator's random keys were reverted to keep the diff focused.

https://claude.ai/code/session_01La3arxaH2yViRaHTCwDVvF

---
_Generated by [Claude Code](https://claude.ai/code/session_01La3arxaH2yViRaHTCwDVvF)_